### PR TITLE
Don't hardocde icon file type

### DIFF
--- a/data/altyo.desktop
+++ b/data/altyo.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=AltYo
 Exec=altyo
-Icon=altyo.png
+Icon=altyo
 Terminal=false
 Type=Application
 Categories=GTK;Utility;TerminalEmulator;

--- a/data/altyo_standalone.desktop
+++ b/data/altyo_standalone.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=AltYo Stand-alone
 Exec=altyo --standalone
-Icon=altyo.png
+Icon=altyo
 Terminal=false
 Type=Application
 Categories=GTK;Utility;TerminalEmulator;


### PR DESCRIPTION
Since the icon already is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the icon file extension in the launcher. It will be found anyway.

This facilitates the use of non-PNG (e.g. SVG) icon themes.
Cf. this [example ``.desktop`` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).